### PR TITLE
OkZoomerCompat, MidnightControlsCompat: Added compatibility with Ok Zoomer 5.0.0-beta.7 (Quilt).

### DIFF
--- a/src/main/java/eu/midnightdust/midnightcontrols/client/compat/MidnightControlsCompat.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/compat/MidnightControlsCompat.java
@@ -39,7 +39,7 @@ public class MidnightControlsCompat {
      * @param mod the mod instance
      */
     public static void init(@NotNull MidnightControlsClient mod) {
-        if (FabricLoader.getInstance().isModLoaded("okzoomer")) {
+        if (FabricLoader.getInstance().isModLoaded("okzoomer") || FabricLoader.getInstance().isModLoaded("ok_zoomer")) {
             mod.log("Adding Ok Zoomer compatibility...");
             HANDLERS.add(new OkZoomerCompat());
         }

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/compat/MidnightControlsCompat.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/compat/MidnightControlsCompat.java
@@ -39,6 +39,8 @@ public class MidnightControlsCompat {
      * @param mod the mod instance
      */
     public static void init(@NotNull MidnightControlsClient mod) {
+        // "okzoomer" is the mod ID used by Fabric-compatible versions of Ok Zoomer. (5.0.0-beta.6 and below.)
+        // "ok_zoomer" is the mod ID used by Quilt-exclusive versions of Ok Zoomer. (5.0.0-beta.7 and above.)
         if (FabricLoader.getInstance().isModLoaded("okzoomer") || FabricLoader.getInstance().isModLoaded("ok_zoomer")) {
             mod.log("Adding Ok Zoomer compatibility...");
             HANDLERS.add(new OkZoomerCompat());

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/compat/OkZoomerCompat.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/compat/OkZoomerCompat.java
@@ -71,9 +71,21 @@ public class OkZoomerCompat implements CompatHandler {
             okZoomerAreExtraKeyBindsEnabledMethodNameString = "areExtraKeybindsEnabled";
         } else if (LambdaReflection.doesClassExist("io.github.ennuil.okzoomer.key_binds.ZoomKeyBinds")) {
             // https://github.com/EnnuiL/OkZoomer/blob/5.0.0-beta.6+1.18.2/src/main/java/io/github/ennuil/okzoomer/key_binds/ZoomKeyBinds.java
-            MidnightControlsClient.get().log("Ok Zoomer version 5.0.0-beta.4 or above detected!");
+            MidnightControlsClient.get().log("Ok Zoomer version 5.0.0-beta.6, 5.0.0-beta.5, or 5.0.0-beta.4 detected!");
 
             okZoomerZoomKeybindsClassString = "io.github.ennuil.okzoomer.key_binds.ZoomKeyBinds";
+
+            okZoomerZoomKeyFieldString = "ZOOM_KEY";
+            okZoomerIncreaseZoomKeyFieldString = "INCREASE_ZOOM_KEY";
+            okZoomerDecreaseZoomKeyFieldString = "DECREASE_ZOOM_KEY";
+            okZoomerResetZoomKeyFieldString = "RESET_ZOOM_KEY";
+
+            okZoomerAreExtraKeyBindsEnabledMethodNameString = "areExtraKeyBindsEnabled";
+        } else if (LambdaReflection.doesClassExist("io.github.ennuil.ok_zoomer.key_binds.ZoomKeyBinds")) {
+            // https://github.com/EnnuiL/OkZoomer/blob/5.0.0-beta.7+1.18.2/src/main/java/io/github/ennuil/ok_zoomer/key_binds/ZoomKeyBinds.java
+            MidnightControlsClient.get().log("Ok Zoomer version 5.0.0-beta.7 (Quilt) or above detected!");
+
+            okZoomerZoomKeybindsClassString = "io.github.ennuil.ok_zoomer.key_binds.ZoomKeyBinds";
 
             okZoomerZoomKeyFieldString = "ZOOM_KEY";
             okZoomerIncreaseZoomKeyFieldString = "INCREASE_ZOOM_KEY";

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/compat/OkZoomerCompat.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/compat/OkZoomerCompat.java
@@ -94,7 +94,7 @@ public class OkZoomerCompat implements CompatHandler {
 
             okZoomerAreExtraKeyBindsEnabledMethodNameString = "areExtraKeyBindsEnabled";
         } else {
-            // If both of the above checks fail, then the version of the Ok Zoomer API that the user is trying to use is too new.
+            // If all of the above checks fail, then the version of the Ok Zoomer API that the user is trying to use is too new.
             MidnightControlsClient.get().warn("The version of Ok Zoomer that you are currently using is too new, and is not yet supported by MidnightControls!");
             return;
         }


### PR DESCRIPTION
OkZoomerCompat, MidnightControlsCompat: Added compatibility with Ok Zoomer 5.0.0-beta.7 (Quilt).

Tested to work on:
* Minecraft 1.18.2, Ok Zoomer 5.0.0-beta.7, quilted-fabric-api/QSL 1.1.0-beta.17 (implementing Fabric API 0.55.1 and QFAPI 1.0.0-beta.19), and Quilt Loader 0.17.0-beta.2.
* Minecraft 1.18.2, Ok Zoomer 5.0.0-beta.6, Fabric API 0.55.1, and Fabric Loader 0.13.3.
* Minecraft 1.18.1, Ok Zoomer 5.0.0-beta.3, Fabric API 0.46.6, and Fabric Loader 0.13.3.

I've also confirmed that it fails gracefully if an user tries to use an invalid combination of the Quilt-exclusive Ok Zoomer 5.0.0-beta.7 with Fabric. (※ In such a case, the `ok_zoomer` mod ID is never loaded, so none of the `OkZoomerCompat` code ever gets touched.)

And yes, MidnightControls works with Quilt.

(In hindsight, I probably should have taken the Quilt version into account back when I made PR #17… oops. Oh well, better late than never, I suppose.)