### PR TITLE
Backport MidnightControls 1.4.1 to 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.19+build.1
 loader_version=0.14.7
 
 # Mod Properties
-mod_version = 1.4.0
+mod_version = 1.4.1
 maven_group = eu.midnightdust
 archives_base_name = midnightcontrols
 modrinth_id=bXX9h73M

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/gui/MidnightControlsHud.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/gui/MidnightControlsHud.java
@@ -86,12 +86,13 @@ public class MidnightControlsHud extends Hud {
         if (this.client == null) return;
         if (MidnightControlsConfig.controlsMode == ControlsMode.CONTROLLER && this.client.currentScreen == null) {
             int y = bottom(2);
+            matrices.push();
             if (scale != 1f) matrices.scale(scale,scale,scale);
             this.renderFirstIcons(matrices, MidnightControlsConfig.hudSide == HudSide.LEFT ? 2 : (int) ((client.getWindow().getScaledWidth() - 2) * (1 / scale)), y);
             this.renderSecondIcons(matrices, MidnightControlsConfig.hudSide == HudSide.RIGHT ? 2 : (int) ((client.getWindow().getScaledWidth() - 2) * (1 / scale)), y);
             this.renderFirstSection(matrices, MidnightControlsConfig.hudSide == HudSide.LEFT ? 2 : (int) ((client.getWindow().getScaledWidth() - 2) * (1 / scale)), y);
             this.renderSecondSection(matrices, MidnightControlsConfig.hudSide == HudSide.RIGHT ? 2 : (int) ((client.getWindow().getScaledWidth() - 2) * (1 / scale)), y);
-            if (scale != 1f) matrices.scale(1,1,1);
+            matrices.pop();
         }
 
         if (this.mod.reacharound.isLastReacharoundVertical()) {

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/mixin/HandledScreenMixin.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/mixin/HandledScreenMixin.java
@@ -62,6 +62,7 @@ public abstract class HandledScreenMixin implements HandledScreenAccessor {
             if (client.options.getGuiScale().getValue() >= 4) {
                 scale = 0.75f;
             } else scale = 1f;
+            matrices.push();
             if (scale != 1f) matrices.scale(scale,scale,scale);
             int x = 2, y = (int) (client.getWindow().getScaledHeight() * (1 / scale) - 2 - MidnightControlsRenderer.ICON_SIZE);
             if (MidnightControlsCompat.isEMIPresent()) {
@@ -80,7 +81,7 @@ public abstract class HandledScreenMixin implements HandledScreenAccessor {
             }
             x = MidnightControlsRenderer.drawButtonTip(matrices, x, y, new int[]{GLFW.GLFW_GAMEPAD_BUTTON_X}, "midnightcontrols.action.pickup", true, client);
             MidnightControlsRenderer.drawButtonTip(matrices, x, y, new int[]{GLFW.GLFW_GAMEPAD_BUTTON_Y}, "midnightcontrols.action.quick_move", true, client);
-            if (scale != 1f) matrices.scale(1,1,1);
+            matrices.pop();
         }
     }
 }


### PR DESCRIPTION
Fixes tooltips in inventories getting displaced when having the GUI scale set to something above 4.