### PR TITLE
Preserve speed when moving diagonally

### DIFF
--- a/src/main/java/eu/midnightdust/midnightcontrols/client/controller/MovementHandler.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/controller/MovementHandler.java
@@ -64,6 +64,7 @@ public final class MovementHandler implements PressAction {
 
         // Do a implicit square here
         movementR = this.slowdownFactor * (Math.pow(this.movementSideways, 2) + Math.pow(this.movementForward, 2));
+        movementR = MathHelper.clamp(movementR, 0.f, 1.f);
         movementTheta = Math.atan2(this.movementForward, this.movementSideways);
         player.input.movementForward = (float) (movementR * Math.sin(movementTheta));
         player.input.movementSideways = (float) (movementR * Math.cos(movementTheta));


### PR DESCRIPTION
The original algorithm squares both X and Y separately, which cause the movement speed to drop by up to half when not moving perfectly along the axes (assuming a full stick push). The new algorithm converts the XY speed vector into a speed and a moving angle vector and only square the speed instead. This prevents the slowdown issue present in the original algorithm.