### PR TITLE
Add extremely basic support for 1.20.4. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ boolean isMCVersionNonRelease() {
 }
 
 String getMCVersionString() {
-    if (isMCVersionNonRelease() || project.minecraft_version == "1.20.2") {
+    if (isMCVersionNonRelease() || project.minecraft_version == "1.20.4") {
         return project.minecraft_version
     }
     def version = project.minecraft_version.split('\\.')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,23 +3,24 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.1
-loader_version=0.14.22
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.2
+loader_version=0.15.1
 
 # Mod Properties
-mod_version = 1.9.0
+mod_version = 1.9.1
 maven_group = eu.midnightdust
 archives_base_name = midnightcontrols
 modrinth_id=bXX9h73M
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.89.2+1.20.2
+fabric_version=0.91.2+1.20.4
 sodium_version=mc1.19.2-0.4.4
-spruceui_version=5.0.3+1.20.2
+spruceui_version=5.0.3+1.20.4
 midnightlib_version=1.5.0-fabric
 modmenu_version=7.0.0
+#9.0.0-pre.1
 emotecraft_version=2.1.3-SNAPSHOT-build.29-MC1.19-fabric
 bendylib_version=2.0.+
 emi_version=0.5.0+1.19.3
@@ -27,6 +28,7 @@ libgui_version=6.0.0+1.19
 inventorytabs_version=inventorytabs-0.9.beta-1.19.x
 clothconfig_version=7.0.72
 yacl_version=2.2.0
+# Update?
 bedrockify_version=1.9+mc1.20
 
 # Ok Zoomer and LibZoomer are temporarily disabled for the time being, as we are currently using Reflection at runtime instead in OkZoomerCompat due to there being two major, completely incompatible API versions.

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/MidnightControlsClient.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/MidnightControlsClient.java
@@ -159,10 +159,10 @@ public class MidnightControlsClient extends MidnightControls implements ClientMo
             GLFW.glfwSetJoystickCallback((jid, event) -> {
                 if (event == GLFW.GLFW_CONNECTED) {
                     var controller = Controller.byId(jid);
-                    client.getToastManager().add(new SystemToast(SystemToast.Type.TUTORIAL_HINT, Text.translatable("midnightcontrols.controller.connected", jid),
+                    client.getToastManager().add(new SystemToast(SystemToast.Type.PERIODIC_NOTIFICATION, Text.translatable("midnightcontrols.controller.connected", jid),
                             Text.literal(controller.getName())));
                 } else if (event == GLFW.GLFW_DISCONNECTED) {
-                    client.getToastManager().add(new SystemToast(SystemToast.Type.TUTORIAL_HINT, Text.translatable("midnightcontrols.controller.disconnected", jid),
+                    client.getToastManager().add(new SystemToast(SystemToast.Type.PERIODIC_NOTIFICATION, Text.translatable("midnightcontrols.controller.disconnected", jid),
                             null));
                 }
 

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/controller/Controller.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/controller/Controller.java
@@ -180,7 +180,7 @@ public record Controller(int id) implements Nameable {
                 var string = l == 0L ? "" : MemoryUtil.memUTF8(l);
                 var client = MinecraftClient.getInstance();
                 if (client != null) {
-                    client.getToastManager().add(SystemToast.create(client, SystemToast.Type.TUTORIAL_HINT,
+		  client.getToastManager().add(SystemToast.create(client, SystemToast.Type.PERIODIC_NOTIFICATION,
                             Text.translatable("midnightcontrols.controller.mappings.error"), Text.literal(string)));
                     MidnightControls.get().log(I18n.translate("midnightcontrols.controller.mappings.error")+string);
                 }

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/gui/MappingsStringInputWidget.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/gui/MappingsStringInputWidget.java
@@ -63,7 +63,7 @@ public class MappingsStringInputWidget extends SpruceContainerWidget {
                 fw.close();
             } catch (IOException e) {
                 if (this.client != null)
-                    this.client.getToastManager().add(SystemToast.create(this.client, SystemToast.Type.TUTORIAL_HINT,
+		  this.client.getToastManager().add(SystemToast.create(this.client, SystemToast.Type.PERIODIC_NOTIFICATION,
                             Text.translatable("midnightcontrols.controller.mappings.error.write"), Text.empty()));
                 e.printStackTrace();
             }

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/gui/ReloadControllerMappingsOption.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/gui/ReloadControllerMappingsOption.java
@@ -33,7 +33,7 @@ public class ReloadControllerMappingsOption {
             Controller.updateMappings();
             if (client.currentScreen instanceof MidnightControlsSettingsScreen)
                 client.currentScreen.init(client, client.getWindow().getScaledWidth(), client.getWindow().getScaledHeight());
-            client.getToastManager().add(SystemToast.create(client, SystemToast.Type.TUTORIAL_HINT,
+            client.getToastManager().add(SystemToast.create(client, SystemToast.Type.PERIODIC_NOTIFICATION,
                     Text.translatable("midnightcontrols.controller.mappings.updated"), Text.empty()));
         }, Text.translatable("midnightcontrols.tooltip.reload_controller_mappings"));
     }


### PR DESCRIPTION
Some menu features not functional and will cause app crashes. Still functional, but don't click the shortcut menus. 

If you don't want to build it yourself you can also use this [midnightcontrols-1.9.1+1.20.4.zip](https://github.com/TeamMidnightDust/MidnightControls/files/13727666/midnightcontrols-1.9.1%2B1.20.4.zip)

