### PR TITLE
Fix Toggle Sprint/Sneak.

### DIFF
--- a/src/main/java/eu/midnightdust/midnightcontrols/client/controller/ButtonBinding.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/controller/ButtonBinding.java
@@ -88,7 +88,7 @@ public class ButtonBinding {
     public static final ButtonBinding SNEAK = new Builder("sneak").buttons(GLFW_GAMEPAD_BUTTON_RIGHT_THUMB)
             .actions(InputHandlers::handleToggleSneak).onlyInGame().cooldown().register();
     public static final ButtonBinding SPRINT = new Builder("sprint").buttons(GLFW_GAMEPAD_BUTTON_LEFT_THUMB)
-            .actions(InputHandlers::handleToggleSprint).onlyInGame().register();
+            .actions(InputHandlers::handleToggleSprint).onlyInGame().cooldown().register();
     public static final ButtonBinding SWAP_HANDS = new Builder("swap_hands").buttons(GLFW_GAMEPAD_BUTTON_X).onlyInGame().cooldown().register();
     public static final ButtonBinding TAB_LEFT = new Builder("tab_back").buttons(GLFW_GAMEPAD_BUTTON_LEFT_BUMPER)
             .action(InputHandlers.handleHotbar(false)).filter(Predicates.or(InputHandlers::inInventory, InputHandlers::inAdvancements).or((client, binding) -> client.currentScreen != null)).cooldown().register();

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/controller/InputHandlers.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/controller/InputHandlers.java
@@ -320,12 +320,12 @@ public class InputHandlers {
             boolean sprintToggled = client.options.getSprintToggled().getValue();
             if (client.player.getAbilities().flying && sprintToggled)
                 client.options.getSprintToggled().setValue(false);
-            else if (MidnightControlsConfig.controllerToggleSneak != sprintToggled)
+            else if (MidnightControlsConfig.controllerToggleSprint != sprintToggled)
                 client.options.getSprintToggled().setValue(!sprintToggled);
             binding.setPressed(button.pressed);
             if (client.player.getAbilities().flying && sprintToggled)
                 client.options.getSprintToggled().setValue(true);
-            else if (MidnightControlsConfig.controllerToggleSneak != sprintToggled)
+            else if (MidnightControlsConfig.controllerToggleSprint != sprintToggled)
                 client.options.getSprintToggled().setValue(sprintToggled);
         });
         return true;


### PR DESCRIPTION
A solution to where Toggle Sprint doesn't work when enabled on its own and is instead unintentionally paired with Toggle Sneak option.