### PR TITLE
Improved Range Combat While Eye Tracking

### DIFF
--- a/src/main/java/eu/midnightdust/midnightcontrols/client/mixin/MouseMixin.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/mixin/MouseMixin.java
@@ -115,8 +115,15 @@ public abstract class MouseMixin implements MouseAccessor {
                 cursorXSmoother.clear();
                 cursorYSmoother.clear();
             }
+            net.minecraft.item.ItemStack items = client.player != null ? client.player.getActiveItem() : net.minecraft.item.ItemStack.EMPTY;
+            boolean isUsingLongRangedTool = (leftButtonClicked &&
+                    items.getUseAction() == net.minecraft.util.UseAction.BOW &&
+                    items.getUseAction() == net.minecraft.util.UseAction.CROSSBOW &&
+                    items.getUseAction() == net.minecraft.util.UseAction.SPEAR)
+                    ||
+                    items.getItem() instanceof net.minecraft.item.ThrowablePotionItem;
             EyeTrackerHandler.updateMouseWithEyeTracking(x + cursorDeltaX, y + cursorDeltaY, client,
-                    lastMouseUpdateTime, leftButtonClicked, cursorXSmoother, cursorYSmoother);
+                    lastMouseUpdateTime, leftButtonClicked, isUsingLongRangedTool, cursorXSmoother, cursorYSmoother);
             lastMouseUpdateTime = GlfwUtil.getTime();
             cursorDeltaX = 0.0;
             cursorDeltaY = 0.0;

--- a/src/main/java/eu/midnightdust/midnightcontrols/client/mouse/EyeTrackerHandler.java
+++ b/src/main/java/eu/midnightdust/midnightcontrols/client/mouse/EyeTrackerHandler.java
@@ -15,6 +15,7 @@ public class EyeTrackerHandler {
                                                   MinecraftClient client,
                                                   double lastMouseUpdateTime,
                                                   boolean holdingLeftMouseButton,
+                                                  boolean usingLongRangedTool,
                                                   SmoothUtil smoothX,
                                                   SmoothUtil smoothY
                                              ) {
@@ -45,7 +46,7 @@ public class EyeTrackerHandler {
         } else {
             frameScalar = moveScalar;
         }
-        if(holdingLeftMouseButton){
+        if(holdingLeftMouseButton && !usingLongRangedTool) {
             frameScalar *= 0.5; //Don't move the camera so much while mining. It's annoying.
         }
 
@@ -68,7 +69,8 @@ public class EyeTrackerHandler {
         if (client.options.getInvertYMouse().getValue()) {
             invertY = -1.0;
         }
-        if (client.player != null && moveMagnitude > MidnightControlsConfig.eyeTrackerDeadzone) {
+        boolean notInDeadzone = (moveMagnitude > MidnightControlsConfig.eyeTrackerDeadzone) && !usingLongRangedTool;
+        if (client.player != null && notInDeadzone) {
             client.player.changeLookDirection(moveX, moveY * invertY);
             client.getTutorialManager().onUpdateMouse(moveX, moveY);
         }


### PR DESCRIPTION
Adjusted the dynamic camera sensitivity while using an item intended to be used at a distance: the bow, crossbow, trident, and splash potion. The deadzone is now ignored, making slight adjustments to aim a little easier. The deadzone was meant to assist mining and building, but it is a hindrance in ranged combat.