### PR TITLE
Fix Network Protocol Error when joining server on NeoForge

### DIFF
--- a/neoforge/src/main/java/eu/midnightdust/midnightcontrols/client/util/platform/neoforge/NetworkUtilImpl.java
+++ b/neoforge/src/main/java/eu/midnightdust/midnightcontrols/client/util/platform/neoforge/NetworkUtilImpl.java
@@ -3,7 +3,7 @@ package eu.midnightdust.midnightcontrols.client.util.platform.neoforge;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.network.packet.Packet;
-import net.minecraft.network.packet.c2s.common.CustomPayloadC2SPacket;
+import net.neoforged.neoforge.network.PacketDistributor;
 
 import static eu.midnightdust.midnightcontrols.client.MidnightControlsClient.client;
 
@@ -19,7 +19,7 @@ public class NetworkUtilImpl {
             handler.send(packet);
     }
     public static void sendPayloadC2S(CustomPayload payload) {
-        if (handler != null && client.world != null)
-            handler.send(new CustomPayloadC2SPacket(payload));
+        if (handler != null && client.world != null && handler.hasChannel(payload.getId().id()))
+            PacketDistributor.sendToServer(payload);
     }
 }


### PR DESCRIPTION
Adds a check to make sure the payload channel actually exists and switched to the correct NeoForge API.
Fixes #326 

Notes:
sendPayloadC2S was updated, but I'm unsure of sendPacketC2S's functionality, although it seems to go unused anyway
The client side handling of ControlsModePayload is loaded within CommonEvents and uses a class using client only APIs, making the packet unusable and logging an error on the server and fixing it is outside my knowledge (trust me, I tried). This is not an issue on fabric due to the fact that the client handling is registered seperately, and I'm unsure if this is possible on neoforge
This issue is likely not exclusive to this branch, it's likely present in all the architectury branches

Will mark draft for now given the server error (non-fatal but could spam logs)